### PR TITLE
chore(release): 1.3.0 [skip ci]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# [1.3.0](https://github.com/mtopn/test-release/compare/v1.2.1...v1.3.0) (2022-07-29)
+
+
+### Bug Fixes
+
+* action yaml ([0262f85](https://github.com/mtopn/test-release/commit/0262f850b9dd9f7bf2d03d89ac5ba5cd2d089ed4))
+* update release config ([b2a9e37](https://github.com/mtopn/test-release/commit/b2a9e370adbac2dcb92c3155478d08650d5c294b))
+
+
+### Features
+
+* add delete route ([3715a51](https://github.com/mtopn/test-release/commit/3715a51253d22e3dad02b4d728a7cff05b3ce961))
+* add PUT route ([f6ee42c](https://github.com/mtopn/test-release/commit/f6ee42c343b43422f18691f8f613c5b33591bf1f))
+* allow get time now ([9bef3e8](https://github.com/mtopn/test-release/commit/9bef3e8078f9966ce79ee12b95f3aa11b1113ea7))
+* post time ([32dd284](https://github.com/mtopn/test-release/commit/32dd2845014d8e08ad2f3a052b60b32ce2ab266b))
+* put time ([a16a370](https://github.com/mtopn/test-release/commit/a16a37078905b1aba0768eff0ef3f2473c013bd1))
+
 # [1.3.0](https://github.com/mtopn/test-release/compare/v1.2.0...v1.3.0) (2022-07-29)
 
 ### Bug Fixes


### PR DESCRIPTION
# [1.3.0](https://github.com/mtopn/test-release/compare/v1.2.1...v1.3.0) (2022-07-29)

### Bug Fixes

* action yaml ([0262f85](https://github.com/mtopn/test-release/commit/0262f850b9dd9f7bf2d03d89ac5ba5cd2d089ed4))
* update release config ([b2a9e37](https://github.com/mtopn/test-release/commit/b2a9e370adbac2dcb92c3155478d08650d5c294b))

### Features

* add delete route ([3715a51](https://github.com/mtopn/test-release/commit/3715a51253d22e3dad02b4d728a7cff05b3ce961))
* add PUT route ([f6ee42c](https://github.com/mtopn/test-release/commit/f6ee42c343b43422f18691f8f613c5b33591bf1f))
* allow get time now ([9bef3e8](https://github.com/mtopn/test-release/commit/9bef3e8078f9966ce79ee12b95f3aa11b1113ea7))
* post time ([32dd284](https://github.com/mtopn/test-release/commit/32dd2845014d8e08ad2f3a052b60b32ce2ab266b))
* put time ([a16a370](https://github.com/mtopn/test-release/commit/a16a37078905b1aba0768eff0ef3f2473c013bd1))